### PR TITLE
Add project management documentation README

### DIFF
--- a/docs/READNE.md
+++ b/docs/READNE.md
@@ -1,0 +1,24 @@
+# OctoAcme Project Management Documentation
+
+Welcome! This README is the central entrypoint to OctoAcme’s project management methodology. It is designed to help all team members quickly discover processes, roles, and key artifacts. By centralizing and standardizing project management knowledge, OctoAcme accelerates onboarding, fosters transparency, and enables repeatable project execution.
+
+## OctoAcme Project Management Processes
+
+OctoAcme operates with a collaborative, customer-focused framework emphasizing clear ownership, iterative delivery, and data-informed decisions. Projects begin with defined initiation steps: assessing business needs, aligning stakeholders, and drafting key artifacts such as the Project One-pager and roadmap. Once authorized, planning breaks work into shippable increments, estimates resources and risks, and drafts backlogs.
+
+Core roles are well-defined—Project Managers (PMs) coordinate delivery and communication; Product Managers (PdMs) set outcomes and priorities; Developers build and test features; QA ensures acceptance criteria and quality; Stakeholders provide inputs and approvals. Throughout the lifecycle, regular communication—weekly syncs, standups, milestone demos—keeps progress transparent and drives alignment. Quality assurance is embedded via automated and manual testing, CI pipelines for linting and security, and structured acceptance reviews.
+
+Risks and blockers are proactively managed through risk registers, routine status reporting, and predefined escalation paths from team-level triage up to sponsor intervention. Continuous improvement is institutionalized: retrospectives after every milestone capture key learnings, feed back refined workflows, and update team knowledge in living documentation. All processes are versioned and maintained in this repository, making every procedure discoverable and auditable.
+
+## Main Process Documents
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning Guide](./octoacme-project-planning.md)
+- [Execution & Tracking Guide](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication Guide](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement Guide](./octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](./octoacme-roles-and-personas.md)
+
+All documentation inside `docs/` is versioned, collaboratively refined, and used as the primary knowledge source for OctoAcme project execution.


### PR DESCRIPTION
This PR adds a centralized README to the docs folder to serve as the main entrypoint for OctoAcme’s project management documentation. The README summarizes key processes, roles, workflows, communication, and quality assurance practices, distilled from all core documentation. It includes direct links to every living process doc for faster navigation and onboarding.

Closes #2 

Reviewer: @Quedin